### PR TITLE
configurable parameters for tftp-proxy systemd service unit

### DIFF
--- a/tftp-proxy.service
+++ b/tftp-proxy.service
@@ -2,7 +2,10 @@
 Description=tftp-proxy
 
 [Service]
-ExecStart=/usr/bin/tftp-proxy -url=http://zerotouch.example.com
+Environment="TFTP_PROXY_UPSTREAM_URL=http://127.0.0.1/tftpboot"
+EnvironmentFile=-/etc/sysconfig/tftp-proxy
+EnvironmentFile=-/etc/default/tftp-proxy
+ExecStart=/usr/bin/tftp-proxy -url=${TFTP_PROXY_UPSTREAM_URL} $TFTP_PROXY_OPTIONS
 
 [Install]
 WantedBy=multi-user.target

--- a/tftp-proxy.sysconfig
+++ b/tftp-proxy.sysconfig
@@ -1,0 +1,17 @@
+## Path:	Productivity/Networking/Ftp/Servers
+## Description: TFTP Proxy configuration
+ 
+## Type:	string
+## Default:	"http://127.0.0.1/tftpboot"
+#
+# URL stem of the upstream HTTP server - the TFTP file request will be
+# suffix to this.
+#
+TFTP_PROXY_UPSTREAM_URL="http://127.0.0.1/tftpboot"
+
+## Type:	string
+## Default:	""
+#
+# extra comand line options to be handed to the TFTP PRoxy program
+#
+TFTP_PROXY_OPTIONS=""


### PR DESCRIPTION
The tftp-proxy systemd service unit should support configurable daemon parameters.

Therefore, this PR defines the variables TFTP_PROXY_UPSTREAM_URL and TFTP_PROXY_OPTIONS
with a default of http://127.0.0.1/tftpboot for the upstream URL and "" (empty) for
further options.  Individual parameters are read from /etc/sysconfig/tftp-proxy and
/etc/default/tftp-proxy, if available, with the latter having higher precedence.